### PR TITLE
Added `-y` to end of `drush updb` to prevent builds with db updates failing

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -16,7 +16,7 @@ tasks:
         service: cli
     - run:
         name: drush updb
-        command: drush updb --cache-clear=0
+        command: drush updb -y --cache-clear=0
         service: cli
     - run:
         name: drush cc all


### PR DESCRIPTION
By amending this, my build no longer failed.

Prior to this, in my logs I would see 
`+++ oc -n life-squared-develop exec cli-19-lvt96 -i -- sh -c 'drush updb --cache-clear=0'
Do you wish to run all pending updates? (y/n): `

And now I see
`Do you wish to run all pending updates? (y/n): y`
followed by all updates running, a success message & a successful deployment in Lagoon UI & my rocket chat CI channel